### PR TITLE
Split log messages into log, warn and error

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,18 @@ LDAP.log: function (message) {
 }
 ```
 
+Additionally you can overwrite the following warn and error functions **on the server** to handle warnings and errors 
+separately (per default they both log their messages on the console if logging is enabled):
+
+```
+LDAP.warn: function (message) {
+  this.log(message);
+},
+LDAP.error: function (message) {
+  this.log(message);
+}
+```
+
 This is a hook you can use **on the server** when a user successfully signs in using LDAP (doesn't fire if the sign in is via the app database when using `LDAP.tryDBFirst`)
 ```
 LDAP.onSignIn(function (userDocument, userData, ldapEntry) {

--- a/ldap_server.js
+++ b/ldap_server.js
@@ -5,6 +5,12 @@ LDAP = {
       console.log(message);
     }
   },
+  warn: function (message) {
+      this.log(message);
+  },
+  error: function (message) {
+      this.log(message);
+  },
   multitenantIdentifier: '',
   searchField: 'cn',
   searchValueType: 'username'
@@ -168,9 +174,9 @@ LDAP._createClient = function () {
   client.starttls(function (err) {
     LDAP.log ('Callback from starting TLS for LDAP:');
     if (err) {
-      LDAP.log(JSON.stringify(err));
-      LDAP.log('LDAP TLS startup failed with error');
-      LDAP.log(JSON.stringify({dn: err.dn, code: err.code, name: err.name, message: err.message}));
+      LDAP.error(JSON.stringify(err));
+      LDAP.error('LDAP TLS startup failed with error');
+      LDAP.error(JSON.stringify({dn: err.dn, code: err.code, name: err.name, message: err.message}));
       tlsFuture.return(false);
     } else {
       tlsFuture.return(true);
@@ -198,9 +204,9 @@ LDAP._bind = function (client, username, password, isEmail, request, settings) {
     client.bind(userDn, password, function (err) {
       LDAP.log ('Callback from binding LDAP:');
       if (err) {
-        LDAP.log(JSON.stringify(err));
-        LDAP.log('LDAP bind failed with error');
-        LDAP.log(JSON.stringify({dn: err.dn, code: err.code, name: err.name, message: err.message}));
+        LDAP.error(JSON.stringify(err));
+        LDAP.error('LDAP bind failed with error');
+        LDAP.error(JSON.stringify({dn: err.dn, code: err.code, name: err.name, message: err.message}));
         bindFuture.return(false);
       } else {
         bindFuture.return(true);
@@ -258,7 +264,7 @@ LDAP._search = function (client, searchUsername, isEmail, request, settings) {
           }
         });
         res.on('error', function (err) {
-          LDAP.log('error: ' + err.message);
+          LDAP.error('error: ' + err.message);
           if (!searchFuture.isResolved()) {
             searchFuture.return(false);
           }
@@ -295,7 +301,7 @@ Accounts.registerLoginHandler("ldap", function (request) {
     return;  
   }
   if (LDAP.multitenantIdentifier && !(request.data && request.data[LDAP.multitenantIdentifier])) {
-    LDAP.log('You need to set "' + LDAP.multitenantIdentifier + '" on the client using LDAP.data for multi-tenant support to work.');
+    LDAP.warn('You need to set "' + LDAP.multitenantIdentifier + '" on the client using LDAP.data for multi-tenant support to work.');
     return;  
   }
   var whatUserTyped = request.username.toLowerCase();
@@ -364,7 +370,7 @@ Accounts.registerLoginHandler("ldap", function (request) {
     /*if (settings.TLS) {
       var tlsStarted = LDAP._starttls(client);
       if (!tlsStarted) {
-        LDAP.log('TLS not started. Not trying to bind to LDAP server.');
+        LDAP.warn('TLS not started. Not trying to bind to LDAP server.');
         return;  
       }
     }*/
@@ -485,7 +491,7 @@ Accounts.registerLoginHandler("ldap", function (request) {
 		  }
 		}
 		else {
-		  LDAP.log('Unable to create user');
+		  LDAP.error('Unable to create user');
 		  console.log(err);  
 		}
 	  }
@@ -500,7 +506,7 @@ Accounts.registerLoginHandler("ldap", function (request) {
 		  if (!_.isEmpty(userObj)) {
 			Meteor.users.update({_id: userId}, {$set: userObj}, function (err, res) {
 			  if (err) {
-				LDAP.log(err);  
+				LDAP.error(err);
 			  }
 			});
 		  }


### PR DESCRIPTION
We would like to log only warning and errors and omit other info messages which will be logged if logging is enabled. Therefore I added the functions LDAP.warn and LDAP.error which pass their message to the LDAP.log function per default. They both can now be overwritten to handle the errors and warnings separately, if desired. I scanned all usages of the LDAP.log function and replaced them by LDAP.warn or LDAP.error depending on the purpose.

Additionally I added a paragraph in the README.md to describe the new functions.