### PR TITLE
Add 'error' event handler to the ldapjs client

### DIFF
--- a/ldap_server.js
+++ b/ldap_server.js
@@ -159,6 +159,11 @@ LDAP._createClient = function () {
       url: serverUrl
     });
   }
+
+  client.on('error', function (error) {
+      LDAP.error('ldapjs client reported an error: ', error);
+  });
+
   return client;
 };
 


### PR DESCRIPTION
If there is no error event handler and an error occurs, e.g. if there is
no ldap server or the connection times out, the node process will die.

To prevent this we will output an error via the LDAP.error() handler.