### PR TITLE
add option to specify attrs retrieved from LDAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,20 @@ You can set `LDAP.searchField` and `LDAP.searchValueType` to be string values or
 The three `LDAP.searchValueType` values that are built in are: `username`, `email`, and `userPrincipalName`.
 
 ```
+LDAP.attributes = [];
+```
+Set this value **on the server** to explicitly specify what attributes you want to return from the LDAP server.
+```
+LDAP.attributes = ['uid', 'cn', 'memberOf'];
+```
+
+You can use this to return only the LDAP attributes that you're interested in, or to request attributes that
+ are *not* returned by default, like OpenLDAP *operational attributes*.
+
+An empty array (the default) will return the default attributes.
+
+
+```
 LDAP.tryDBFirst = true;
 ```
 **on the server** if you want the package to try and log the user in using the app database before hitting the LDAP server. (This is `false` by default.)

--- a/ldap_server.js
+++ b/ldap_server.js
@@ -73,6 +73,9 @@ LDAP.userLookupQuery = function (fieldName, fieldValue, isEmail, isMultitenantId
   return selector;
 }
 
+// this contains the LDAP attributes to fetch - an empty array means all user attributes
+LDAP.attributes = [];
+
 LDAP.addFields = function (entry) {
   // `this` is the request from the client
   // `entry` is the object returned from the LDAP server
@@ -233,7 +236,8 @@ LDAP._search = function (client, searchUsername, isEmail, request, settings) {
   // Search our previously bound connection. If the LDAP client isn't bound, this should throw an error.
   var opts = {
     scope: 'sub',
-    timeLimit: 2
+    timeLimit: 2,
+    attributes: LDAP.attributes
   };
   var serverDNs = (typeof(settings.serverDn) == 'string') ? [settings.serverDn] : settings.serverDn;
   var result = false;


### PR DESCRIPTION
This adds a new configurable property to the LDAP object: `LDAP.attributes`
When set, it specifies a list of attributes to explicitly fetch from LDAP in the search-phase.
(I originally needed this to force fetching of operational attributes, but it might also be useful for trimming LDAP entries that have a gazillion attributes you don't care about)