### PR TITLE
fixed a Mongo error when trying to update Users with empty object

### DIFF
--- a/ldap_server.js
+++ b/ldap_server.js
@@ -465,6 +465,7 @@ Accounts.registerLoginHandler("ldap", function (request) {
 		userId = Accounts.createUser(tempUserObj);
 		user = Meteor.users.findOne({_id: userId});
 		if (user) {
+		  console.log(extraFields);
 		  Meteor.users.update({_id: userId}, {$set: extraFields});  
 		}
 	  }

--- a/ldap_server.js
+++ b/ldap_server.js
@@ -464,8 +464,7 @@ Accounts.registerLoginHandler("ldap", function (request) {
 		});
 		userId = Accounts.createUser(tempUserObj);
 		user = Meteor.users.findOne({_id: userId});
-		if (user) {
-		  console.log(extraFields);
+		if (user && !_.isEmpty(extraFields)) {
 		  Meteor.users.update({_id: userId}, {$set: extraFields});  
 		}
 	  }


### PR DESCRIPTION
error log: 

{ [MongoError: '$set' is empty. You must specify a field like so: {$set: {<field>: ...}}]
name: 'MongoError',
message: '\'$set\' is empty. You must specify a field like so: {$set: {<field>: ...}}',
driver: true,
index: 0,
code: 9,
errmsg: '\'$set\' is empty. You must specify a field like so: {$set: {<field>: ...}}' }